### PR TITLE
Bump runtime to 21.08

### DIFF
--- a/com.brosix.Brosix.json
+++ b/com.brosix.Brosix.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.brosix.Brosix",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "19.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "Brosix.sh",
     "finish-args": [
@@ -9,9 +9,8 @@
         "--share=network",
         "--socket=pulseaudio",
         "--socket=x11",
-        "--socket=wayland",
         "--device=all",
-        "--filesystem=home:rw"
+        "--filesystem=home"
     ],
     "modules": [
 	{
@@ -26,8 +25,25 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.12.8.tar.bz2",
-                    "sha256": "cae7a55a6a1330e7b4297190847793d501b6f3e2248fb9571ab895034ca0aebc"
+                    "url": "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.22.1.tar.bz2",
+                    "sha256": "65c6fbe830a44ca105c443b027182c1b2c9053a91d1e72ad849dfab388b94e31"
+                }
+            ]
+        },
+        {
+            "name": "krb5",
+            "subdir": "src",
+            "config-opts": [
+                    "--localstatedir=/var/lib",
+                    "--sbindir=${FLATPAK_DEST}/bin",
+                    "--disable-rpath",
+                    "--disable-static"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://kerberos.org/dist/krb5/1.20/krb5-1.20.tar.gz",
+                    "sha256": "7e022bdd3c851830173f9faaa006a230a0e0fdad4c953e85bff4bf0da036e12f"
                 }
             ]
         },
@@ -46,7 +62,7 @@
                     "type": "archive",
                     "dest": "Brosix",
                     "url": "https://www.brosix.com/downloads/builds/official/Brosix_x64.tar.gz",
-                    "sha256": "7443de2adbdbd85da42af23fba5f5636c01afd15bd7f76d05d06bdbec2133dee"
+                    "sha256": "2a3fd2fb3f69e23f13d5e7a0dd9cfa2acf117fe06ccce3598b25dbceb622bbb5"
                 },
 		{
 		    "type": "file",

--- a/com.brosix.Brosix.metainfo.xml
+++ b/com.brosix.Brosix.metainfo.xml
@@ -18,6 +18,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="4.7.2 Build 220525.13731" date="2022-05-25"/>
     <release version="4.5 Build 200326.12251" date="2020-03-26"/>
     <release version="4.5 Build 200309.12214" date="2020-03-09"/>
     <release version="4.4 Build 191217.12013" date="2019-12-17"/>

--- a/com.brosix.Brosix.metainfo.xml
+++ b/com.brosix.Brosix.metainfo.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>com.brosix.Brosix.desktop</id>
+  <id>com.brosix.Brosix</id>
+  <provides>
+    <id>com.brosix.Brosix.desktop</id>
+  </provides>
+  <launchable type="desktop-id">com.brosix.Brosix.desktop</launchable>
   <name>Brosix</name>
   <project_license>LicenseRef-proprietary</project_license>
   <developer_name>brosix.com</developer_name>


### PR DESCRIPTION
- Update v4l-utils to 1.22.1
- Add krb5 as a dependency of Brosix
- Update Brosix to latest release
- Improve permissions

This doesn't work with Wayland at all:

```
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: xcb.
```

Ping @karlos1841 please review when you have time, thanks!